### PR TITLE
1.1.1 Hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.1.1] - 2023-01-17
+
 ### Fixed
 
 - Fixed being unable to manipulate nodes after leaving readonly mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed being unable to manipulate nodes after leaving readonly mode
+
 ## [1.1.0] - 2023-01-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed being unable to manipulate nodes after leaving readonly mode
 - Fixed edges from being editable in readonly mode
 - Fixed null exception errors sometimes occuring inbetween play and edit mode
+- Fixed function nodes not showing inspector view inside their body when simple node view was false
 
 ## [1.1.0] - 2023-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed being unable to manipulate nodes after leaving readonly mode
+- Fixed edges from being editable in readonly mode
+- Fixed null exception errors sometimes occuring inbetween play and edit mode
 
 ## [1.1.0] - 2023-01-16
 

--- a/Documentation~/RuntimeVisualisation.md
+++ b/Documentation~/RuntimeVisualisation.md
@@ -28,7 +28,7 @@ public override void OnSelectionChange()
     {
         DTRunner dtRunner = Selection.activeObject?.GetComponent<DTRunner>();
         if (dtRunner?.DecisionTree && Application.isPlaying)
-            TreeView.PopulateView(dtRunner.DecisionTree);
+            TreeView?.PopulateView(dtRunner.DecisionTree);
     }
     else
     {
@@ -41,7 +41,7 @@ public override void OnSelectionChange()
 
 To begin with we get our active selection and try cast it directly as a Decision Tree. If we have selected a decision tree then we can just load that one like normal. However, if the cast returns null that means we haven't selected a decision tree. Therefore we *might* have selected our object that has a component that uses the decision tree.
 
-To extract the decision tree we just have to get the comonent that has it from our selected object. Then check if our component has a decision tree set. We also want to make sure we are in playmode so we have loaded the cloned version of the tree that the component would be using. Once we have confirmed this we can just populate the view with that decision tree rather than the saved decision tree in the asset database.
+To extract the decision tree we just have to get the comonent that has it from our selected object. Then check if our component has a decision tree set. We also want to make sure we are in playmode so we have loaded the cloned version of the tree that the component would be using. Once we have confirmed this we can just populate the view with that decision tree rather than the saved decision tree in the asset database. We only want to call the `PopulateView` function if our TreeView isn't null. Sometimes this `OnSelectionChange` can fire before the TreeView has been initialised. This will prevent a null exception error.
 
 You can check if the visual editor is using your custom one by checking the title of the decision tree editor. It should contain (custom) at the end of the title. You can also just put a debug log inside your custom editor's OnSelectionChange.
 

--- a/Editor/DecisionTreeEditor.cs
+++ b/Editor/DecisionTreeEditor.cs
@@ -153,7 +153,7 @@ namespace KieranCoppins.DecisionTreesEditor
         {
             DecisionTree decisionTree = Selection.activeObject as DecisionTree;
             if (decisionTree && AssetDatabase.CanOpenAssetInEditor(decisionTree.GetInstanceID()))
-                TreeView.PopulateView(decisionTree);
+                TreeView?.PopulateView(decisionTree);
         }
 
         /// <summary>

--- a/Editor/DecisionTreeView.cs
+++ b/Editor/DecisionTreeView.cs
@@ -128,6 +128,14 @@ namespace KieranCoppins.DecisionTreesEditor
                 this.RemoveManipulator(_rectangleSelector);
                 this.RemoveManipulator(_selectionDragger);
             }
+            else
+            {
+                if (_selectionDragger.target == null && _rectangleSelector.target == null) 
+                {
+                    this.AddManipulator(_selectionDragger);
+                    this.AddManipulator(_rectangleSelector);
+                }
+            }
             this.Q<Label>("Title").text = _tree.IsClone ? "Tree View (Read-Only)" : "Tree View";
         }
 

--- a/Editor/DecisionTreeView.cs
+++ b/Editor/DecisionTreeView.cs
@@ -114,7 +114,7 @@ namespace KieranCoppins.DecisionTreesEditor
                 {
                     Edge edge = outputNode.OutputPorts[input.OutputPortName].ConnectTo(inputNode.InputPorts[input.InputPortName]);
                     if (_tree.IsClone)
-                        edge.capabilities = Capabilities.Selectable;
+                        edge.SetEnabled(false);
 
                     inputNode.ConnectedNodes.Add(outputNode);
                     outputNode.ConnectedNodes.Add(inputNode);

--- a/Editor/FunctionNodeView.cs
+++ b/Editor/FunctionNodeView.cs
@@ -9,8 +9,13 @@ namespace KieranCoppins.DecisionTreesEditor
 {
     public class FunctionNodeView : BaseNodeView
     {
+        private InspectorView _nodeInspectorView;
+
         public FunctionNodeView(object function) : base(function as DecisionTreeEditorNodeBase)
         {
+            _nodeInspectorView = this.Q<InspectorView>();
+            _nodeInspectorView.UpdateSelection(this);
+
             CreateInputPorts();
 
             // Function nodes should only ever have 1 output node

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Unity package containing creating and editing decision trees. Including the de
 - [Features](#features)
 - [How to Install](#how-to-install)
 - [Documentation](Documentation~/README.md)
+- [Changelog](CHANGELOG.md)
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.kierancoppins.decision-trees",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "displayName": "Decision Trees",
     "description": "Create decision trees using this custom editor for your AI!",
     "unity": "2021.3",


### PR DESCRIPTION
## [1.1.1] - 2023-01-17

### Fixed

- Fixed being unable to manipulate nodes after leaving readonly mode
- Fixed edges from being editable in readonly mode
- Fixed null exception errors sometimes occuring inbetween play and edit mode
- Fixed function nodes not showing inspector view inside their body when simple node view was false