### PR TITLE
V1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Colours depending on function data types
+
+### Fixed
+
+- Fixed Function nodes and parameter inputs of mismatching types being able to connect
+
 ## [1.1.1] - 2023-01-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A tooltip appears over each port displaying the type they expect
 - Logic edges are denoted by being thicker
 
+### Changed
+
+- Removed context menu whilst in read-only mode
+
 ### Fixed
 
 - Fixed Function nodes and parameter inputs of mismatching types being able to connect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.2.0] - 2023-01-20
+
 ### Added
 
 - Colours depending on function data types. Default colour is blue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Colours depending on function data types
+- Colours depending on function data types. Default colour is blue
+- A tooltip appears over each port displaying the type they expect
+- Logic edges are denoted by being thicker
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Colours depending on function data types. Default colour is blue
 - A tooltip appears over each port displaying the type they expect
 - Logic edges are denoted by being thicker
+- New context menu option *"Open in IDE"* on nodes, opens the script for these nodes in your IDE
 
 ### Changed
 

--- a/Editor/DecisionTreeEditor.uss
+++ b/Editor/DecisionTreeEditor.uss
@@ -9,3 +9,11 @@ GridBackground {
     width: 100%;
     height: 100%;
 }
+
+.edge.LogicEdge {
+    --edge-width: 6;
+}
+
+.edge.LogicEdge:hover {
+    --edge-width: 8;
+}

--- a/Editor/DecisionTreeNodeView.cs
+++ b/Editor/DecisionTreeNodeView.cs
@@ -1,6 +1,7 @@
 using UnityEditor.Experimental.GraphView;
 using KieranCoppins.DecisionTrees;
 using UnityEngine.UIElements;
+using System.Drawing;
 
 namespace KieranCoppins.DecisionTreesEditor
 {
@@ -43,7 +44,7 @@ namespace KieranCoppins.DecisionTreesEditor
             if (Node is RootNode)
                 return;
 
-            Port port = InstantiatePort(Orientation.Vertical, Direction.Input, Port.Capacity.Single, typeof(bool));
+            Port port = InstantiatePort(Orientation.Vertical, Direction.Input, Port.Capacity.Single, typeof(LogicPortType));
             port.portName = "Entry";
             port.name = "main";
             InputPorts.Add("main", port);
@@ -57,9 +58,11 @@ namespace KieranCoppins.DecisionTreesEditor
                 {
                     foreach (var parameter in constructor.GetParameters())
                     {
-                        port = InstantiatePort(Orientation.Vertical, Direction.Input, Port.Capacity.Single, parameter.ParameterType);
+                        port = InstantiatePort(Orientation.Vertical, Direction.Input, Port.Capacity.Single, parameter.ParameterType.GetGenericArguments()[0]);
                         port.portName = parameter.Name;
                         port.name = parameter.Name;
+                        port.portColor = GetColorForType(parameter.ParameterType);
+                        port.tooltip = parameter.ParameterType.GetGenericArguments()[0].ToString();
                         InputPorts.Add(parameter.Name, port);
                         inputContainer.Add(port);
                     }
@@ -78,14 +81,14 @@ namespace KieranCoppins.DecisionTreesEditor
             }
             else if (Node is Decision)
             {
-                Port port = InstantiatePort(Orientation.Vertical, Direction.Output, Port.Capacity.Single, typeof(bool));
+                Port port = InstantiatePort(Orientation.Vertical, Direction.Output, Port.Capacity.Single, typeof(LogicPortType));
                 port.portName = "TRUE";
                 port.name = "TRUE";
                 OutputPorts.Add("TRUE", port);
                 outputContainer.Add(port);
 
 
-                port = InstantiatePort(Orientation.Vertical, Direction.Output, Port.Capacity.Single, typeof(bool));
+                port = InstantiatePort(Orientation.Vertical, Direction.Output, Port.Capacity.Single, typeof(LogicPortType));
                 port.name = "FALSE";
                 port.portName = "FALSE";
                 OutputPorts.Add("FALSE", port);
@@ -93,7 +96,7 @@ namespace KieranCoppins.DecisionTreesEditor
             }
             else if (Node is RootNode)
             {
-                Port port = InstantiatePort(Orientation.Vertical, Direction.Output, Port.Capacity.Single, typeof(bool));
+                Port port = InstantiatePort(Orientation.Vertical, Direction.Output, Port.Capacity.Single, typeof(LogicPortType));
                 port.name = "main";
                 port.portName = "";
                 OutputPorts.Add("main", port);
@@ -101,4 +104,9 @@ namespace KieranCoppins.DecisionTreesEditor
             }
         }
     }
+}
+
+public class LogicPortType
+{
+    public LogicPortType() { }
 }

--- a/Editor/DecisionTreeView.cs
+++ b/Editor/DecisionTreeView.cs
@@ -144,6 +144,9 @@ namespace KieranCoppins.DecisionTreesEditor
 
         public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
         {
+            if (_tree.IsClone)
+                return;
+
             Vector2 clickPoint = viewTransform.matrix.inverse.MultiplyPoint(evt.localMousePosition);
             GridBackground grid = contentContainer[0] as GridBackground;
             var types = TypeCache.GetTypesDerivedFrom<DecisionTreeEditorNodeBase>();
@@ -201,7 +204,10 @@ namespace KieranCoppins.DecisionTreesEditor
                 nodeView.capabilities = Capabilities.Selectable | Capabilities.Movable | Capabilities.Ascendable | Capabilities.Snappable;
 
             if (_tree.IsClone)
+            {
                 nodeView.capabilities = Capabilities.Selectable;
+                nodeView.ReadOnly = true;
+            }
 
             AddElement(nodeView);
         }
@@ -215,8 +221,13 @@ namespace KieranCoppins.DecisionTreesEditor
             FunctionNodeView nodeView = new(node);
             nodeView.OnNodeSelected = OnNodeSelected;
             nodeView.AddToClassList(SimpleNodeView ? "simple" : "complex");
+
             if (_tree.IsClone)
+            {
                 nodeView.capabilities = Capabilities.Selectable;
+                nodeView.ReadOnly = true;
+            }
+
             AddElement(nodeView);
         }
 

--- a/Editor/FunctionNodeView.cs
+++ b/Editor/FunctionNodeView.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 using UnityEditor.Experimental.GraphView;
 using UnityEngine.UIElements;
 using KieranCoppins.DecisionTrees;
+using System.Data.Common;
+using System.Runtime.InteropServices;
 
 namespace KieranCoppins.DecisionTreesEditor
 {
@@ -18,10 +20,23 @@ namespace KieranCoppins.DecisionTreesEditor
 
             CreateInputPorts();
 
+            System.Type type = null;
+            System.Type current = function.GetType();
+            while (type == null && current != typeof(object))
+            {
+                if (current.IsGenericType)
+                {
+                    type = current;
+                }
+                current = current.BaseType;
+            }
+
             // Function nodes should only ever have 1 output node
-            Port port = InstantiatePort(Orientation.Vertical, Direction.Output, Port.Capacity.Multi, GenericHelpers.GenericHelpers.GetGenericType(function));
+            Port port = InstantiatePort(Orientation.Vertical, Direction.Output, Port.Capacity.Multi, type.GetGenericArguments()[0]);
             port.portName = "Output";
             port.name = "Output";
+            port.tooltip = type.GetGenericArguments()[0].ToString();
+            port.portColor = GetColorForType(type);
             OutputPorts.Add("Output", port);
             outputContainer.Add(port);
             AddToClassList("function");
@@ -45,6 +60,8 @@ namespace KieranCoppins.DecisionTreesEditor
                         Port port = InstantiatePort(Orientation.Vertical, Direction.Input, Port.Capacity.Single, parameter.ParameterType);
                         port.portName = parameter.Name;
                         port.name = parameter.Name;
+                        port.portColor = GetColorForType(parameter.ParameterType);
+                        port.tooltip = parameter.ParameterType.GetGenericArguments()[0].ToString();
                         InputPorts.Add(parameter.Name, port);
                         inputContainer.Add(port);
                     }

--- a/Runtime/DecisionTree.cs
+++ b/Runtime/DecisionTree.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEditor;
 using UnityEditor.Experimental.GraphView;
 using UnityEngine.UIElements;
+using System.Data.Common;
 
 namespace KieranCoppins.DecisionTrees
 {
@@ -402,6 +403,21 @@ namespace KieranCoppins.DecisionTrees
     /// </summary>
     public abstract class BaseNodeView : Node
     {
+        /// <summary>
+        /// A dictionary containing datatype to colours
+        /// </summary>
+        public static IDictionary<Type, Color> TypeColourDictionary = new Dictionary<Type, Color>()
+        {
+            {typeof(float), new Color(.243f, .980f, .265f) },
+            {typeof(int), new Color(.243f, .980f, .265f) },
+            {typeof(decimal), new Color(.243f, .980f, .265f) },
+            {typeof(long), new Color(.243f, .980f, .265f) },
+            {typeof(bool), new Color(.980f, .243f, .243f)},
+            {typeof(string), new Color(.936f, .243f, .980f) },
+            {typeof(char), new Color(.936f, .243f, .980f) },
+            {typeof(Vector2), new Color(.690f, .980f, .243f) },
+            {typeof(Vector3), new Color(.690f, .980f, .243f) },
+        };
         public Action<BaseNodeView> OnNodeSelected { get; set; }
 
         /// <summary>
@@ -547,8 +563,11 @@ namespace KieranCoppins.DecisionTrees
             }
         }
 
+        protected static Color GetColorForType(Type type)
+        {
+            return TypeColourDictionary.ContainsKey(type.GetGenericArguments()[0]) ? TypeColourDictionary[type.GetGenericArguments()[0]] : new Color(.243f, .265f, .980f);
+        }
     }
-
     public class EnumFlagsAttribute : PropertyAttribute
     {
 

--- a/Runtime/DecisionTree.cs
+++ b/Runtime/DecisionTree.cs
@@ -444,6 +444,8 @@ namespace KieranCoppins.DecisionTrees
         private readonly Label _errorLabel;
         private readonly VisualElement _errorContainer;
 
+        public bool ReadOnly { get; set; }
+
         /// <summary>
         /// The description that is applied to the node view inside the visual editor
         /// </summary>
@@ -566,6 +568,11 @@ namespace KieranCoppins.DecisionTrees
         protected static Color GetColorForType(Type type)
         {
             return TypeColourDictionary.ContainsKey(type.GetGenericArguments()[0]) ? TypeColourDictionary[type.GetGenericArguments()[0]] : new Color(.243f, .265f, .980f);
+        }
+        public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
+        {
+            if (!ReadOnly)
+                base.BuildContextualMenu(evt);
         }
     }
     public class EnumFlagsAttribute : PropertyAttribute

--- a/Runtime/DecisionTree.cs
+++ b/Runtime/DecisionTree.cs
@@ -572,7 +572,15 @@ namespace KieranCoppins.DecisionTrees
         public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
         {
             if (!ReadOnly)
+            {
+                // Add an option to be able to open the script of the Node in an IDE
+                evt.menu.AppendAction("Open in IDE", (a) => {
+                    string[] guids = AssetDatabase.FindAssets($"{Node.GetType().Name} t:script", null);
+                    if (guids.Length > 0)
+                        AssetDatabase.OpenAsset(MonoImporter.GetAtPath(AssetDatabase.GUIDToAssetPath(guids[0])).GetInstanceID());
+                });
                 base.BuildContextualMenu(evt);
+            }
         }
     }
     public class EnumFlagsAttribute : PropertyAttribute

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.kierancoppins.decision-trees",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "displayName": "Decision Trees",
     "description": "Create decision trees using this custom editor for your AI!",
     "unity": "2021.3",


### PR DESCRIPTION
## [1.2.0] - 2023-01-20

### Added

- Colours depending on function data types. Default colour is blue
- A tooltip appears over each port displaying the type they expect
- Logic edges are denoted by being thicker
- New context menu option *"Open in IDE"* on nodes, opens the script for these nodes in your IDE

### Changed

- Removed context menu whilst in read-only mode

### Fixed

- Fixed Function nodes and parameter inputs of mismatching types being able to connect